### PR TITLE
refactor #161: 

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -45,7 +45,7 @@ load_dotenv("src/parquet/.env") # src/parquet/.env를 사용하는 이유: Graph
 app = Flask(__name__)   # Flask 앱 객체 생성. 해당 파일이 서버의 메인 애플리케이션이라는 의미
 CORS(app)   # Cross-Origin Resource Sharing 허용 (다른 환경에서 이 서버의 API를 호출할 수 있도록)
 
-WEBAPP_URL = "https://script.google.com/macros/s/AKfycbw7KX3gzE6do2sqDAlWlBsHFNwIX_ZCUILUNipin87mIyIw1_HhKWUHC0oLhM8pHUVhfA/exec"
+WEBAPP_URL = "https://script.google.com/macros/s/AKfycbzsZy_kzf3H0sJkvEhjczIHidzOAUs-I8E-jAJI6YXYPqo-FZqZNH-rVAS4N5a_w1V-/exec"
 
 
 # 한글 출력 시 깨지거나 에러 나는 것 방지 (utf-8 인코딩 및 대체 문자 처리)
@@ -1282,6 +1282,9 @@ def calendar_events():
     except Exception:
         return jsonify({"events": [], "error": res.text[:200]}), 200
 
+
+
+# 엔드포인트: POST /labels-proxy (Apps Script 라벨 프록시)
 # 엔드포인트: POST /labels-proxy (Apps Script 라벨 프록시)
 @app.route('/labels-proxy', methods=['POST'])
 def labels_proxy():
@@ -1323,58 +1326,54 @@ def labels_proxy():
 
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
-    
 
 
-
-
-# 라벨 서치 프롬포트: 사용자 의도를 "action"(라벨 적용) vs "query"(정보 질문)으로 분류
-with open(os.path.join("parquet_template", "prompts", "label_search_prompt.txt"), "r", encoding="utf-8") as _f:
-    LABEL_SEARCH_PROMPT = _f.read().strip()
-
-# 엔드포인트: POST /label-route (라벨 서치 프롬포트로 의도 분류)
+# 엔드포인트: POST /label-route — deprecated, /label-query 로 직접 호출하세요
 @app.route("/label-route", methods=["POST"])
-def label_route():
+def label_route_deprecated():
     data = request.json or {}
-    user_input = data.get("userInput", "").strip()
-    label_names = data.get("labels", [])  # 현재 라벨 목록 (컨텍스트용)
+    with app.test_request_context(
+        '/label-query', method='POST',
+        json=data, content_type='application/json'
+    ):
+        result = label_query()
+    result_data = result.get_json()
+    if not result_data.get("ok"):
+        return jsonify(result_data)
+    return jsonify({"ok": True, "intent": result_data.get("intent", "query")})
 
-    if not user_input:
-        return jsonify({"ok": False, "error": "userInput이 비어있습니다."}), 400
-
-    system_content = LABEL_SEARCH_PROMPT
-    if label_names:
-        system_content += f"\n\n현재 사용자의 라벨 목록: {', '.join(label_names)}"
-
-    try:
-        client = openai.OpenAI(api_key=os.environ.get("GRAPHRAG_API_KEY"))
-        response = client.chat.completions.create(
-            model="gpt-4o-mini",
-            messages=[
-                {"role": "system", "content": system_content},
-                {"role": "user", "content": user_input}
-            ],
-            response_format={"type": "json_object"},
-            temperature=0
-        )
-        result = json.loads(response.choices[0].message.content)
-        intent = result.get("intent", "query")
-        if intent not in ("action", "query"):
-            intent = "query"
-        return jsonify({"ok": True, "intent": intent})
-
-    except Exception as e:
-        return jsonify({"ok": False, "error": str(e)}), 500
-
-
-# 엔드포인트: POST /label-query (라벨 특화 질의 - OpenAI Function Calling)
+# 엔드포인트: POST /label-query (라벨 특화 질의 - 의도 분류 + OpenAI Function Calling)
 @app.route("/label-query", methods=["POST"])
 def label_query():
-    data = request.json or {}
-    user_input = data.get("userInput", "").strip()
+    data        = request.json or {}
+    user_input  = data.get("userInput", "").strip()
+    label_names = data.get("labels", [])
 
     if not user_input:
         return jsonify({"ok": False, "error": "userInput이 비어있습니다."}), 400
+
+    system_content = (
+        "사용자의 Gmail 관련 요청을 분석하세요.\n\n"
+
+        "【작업 요청】메일을 검색·분류·삭제·이동·라벨 추가·라벨 제거하는 요청이면 "
+        "반드시 아래 함수 중 하나를 호출하세요.\n"
+        "  - search_emails : 메일 검색 후 라벨 적용\n"
+        "  - apply_label   : 이미 선택된 메일에 라벨만 적용\n"
+        "  - trash_emails  : 메일을 휴지통으로 이동\n"
+        "  - remove_label  : 메일에서 라벨 제거\n"
+        "  - create_label  : 새 라벨 생성\n\n"
+
+        "【정보 질문】메일 내용이나 현황에 대한 질문 "
+        "(예: '받은 메일 중 중요한 게 뭐야?', '최근 메일 요약해줘', "
+        "'어떤 라벨에 메일이 많아?', '내 메일함 분석해줘') 이면 "
+        "함수를 호출하지 마세요. 아무 함수도 호출하지 않으면 "
+        "시스템이 자동으로 GraphRAG 지식 베이스 검색으로 답변합니다.\n\n"
+
+        "판단이 애매할 때는 작업 요청으로 처리하세요."
+    )
+
+    if label_names:
+        system_content += f"\n\n현재 사용자의 라벨 목록: {', '.join(label_names)}"
 
     tools = [
         {
@@ -1391,7 +1390,7 @@ def label_query():
                         },
                         "label_to_apply": {
                             "type": "string",
-                            "description": "검색된 메일에 적용할 라벨명 (예: 테스트). 언급이 없으면 빈 문자열."
+                            "description": "검색된 메일에 적용할 라벨명. 언급이 없으면 빈 문자열."
                         }
                     },
                     "required": ["query", "label_to_apply"]
@@ -1441,7 +1440,7 @@ def label_query():
             "type": "function",
             "function": {
                 "name": "remove_label",
-                "description": "삭제하거나 휴지통으로 이동할 메일의 검색 키워드를 추출합니다. '삭제해줘', '지워줘', '휴지통으로 이동해줘' 같은 요청에 사용합니다.",
+                "description": "메일에서 특정 라벨을 제거합니다. '라벨 빼줘', '라벨 제거해줘' 같은 요청에 사용합니다.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -1458,7 +1457,6 @@ def label_query():
                 }
             }
         },
-        # ✅ 추가
         {
             "type": "function",
             "function": {
@@ -1483,37 +1481,42 @@ def label_query():
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "사용자의 Gmail 메일 관리 요청을 분석하여 적절한 함수를 호출하세요. "
-                        "메일을 검색해서 라벨을 붙이거나 찾는 요청이면 search_emails를 사용하세요. "
-                        "이미 선택된 메일에 라벨만 적용하는 요청이면 apply_label을 사용하세요. "
-                        "메일을 삭제하거나 휴지통으로 이동하는 요청이면 trash_emails를 사용하세요. "
-                        "메일에서 라벨을 제거하는 요청이면 remove_label을 사용하세요. "
-                        "새 라벨을 만드는 요청이면 create_label을 사용하세요."  # ✅ 추가
-                    )
-                },
-                {"role": "user", "content": user_input}
+                {"role": "system", "content": system_content},
+                {"role": "user",   "content": user_input}
             ],
             tools=tools,
-            tool_choice="auto"
+            tool_choice="auto",
+            temperature=0
         )
+
         tool_calls = response.choices[0].message.tool_calls
 
-        # 단일 액션
+        if not tool_calls:
+            print("[label-query] FC 없음 → intent=query")
+            return jsonify({"ok": True, "intent": "query"})
+
         if len(tool_calls) == 1:
             action = tool_calls[0].function.name
             params = json.loads(tool_calls[0].function.arguments)
-            return jsonify({"ok": True, "action": action, "params": params})
+            print(f"[label-query] 단일 액션: {action} / params: {params}")
+            return jsonify({
+                "ok":     True,
+                "intent": "action",
+                "action": action,
+                "params": params
+            })
 
-        # 복합 액션 (예: create_label + search_emails)
-        else:
-            actions = [
-                {"action": tc.function.name, "params": json.loads(tc.function.arguments)}
-                for tc in tool_calls
-            ]
-            return jsonify({"ok": True, "action": "multi", "actions": actions})
+        actions = [
+            {"action": tc.function.name, "params": json.loads(tc.function.arguments)}
+            for tc in tool_calls
+        ]
+        print(f"[label-query] 복합 액션: {[a['action'] for a in actions]}")
+        return jsonify({
+            "ok":      True,
+            "intent":  "action",
+            "action":  "multi",
+            "actions": actions
+        })
 
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500

--- a/src/apps-script/common.js
+++ b/src/apps-script/common.js
@@ -1,7 +1,7 @@
 // src/apps-script/common.js
 var TunnelURL = "https://detainable-thumbless-arnav.ngrok-free.dev"; // ngrok로 열어둔 백엔드 서버(Flask/GraphRAG) 주소
 const WEBAPP_URL =
-  "https://script.google.com/macros/s/AKfycbxQN-o7ZKI-daT-D-8h9YLo63IUefp9ShJGpZxWEPwuh1A6gH6kNMrzwP07o46eh6WE/exec"; // Apps Script Web App으로 배포된 URL
+  "https://script.google.com/macros/s/AKfycbzsZy_kzf3H0sJkvEhjczIHidzOAUs-I8E-jAJI6YXYPqo-FZqZNH-rVAS4N5a_w1V-/exec"; // Apps Script Web App으로 배포된 URL
 
 const OLIVE = "#c6d8a5";
 

--- a/src/web/production/contacts.html
+++ b/src/web/production/contacts.html
@@ -1070,7 +1070,7 @@ let searchQuery = '';
 let alphaFilter = 'all';
 let sortMode = 'name';
 let currentPage = 1;
-const PER_PAGE = 6;
+const PER_PAGE = 10;
 let editingId = null;
 let composeTarget = null;
 

--- a/src/web/production/index2.html
+++ b/src/web/production/index2.html
@@ -1102,6 +1102,34 @@
         el.innerHTML = `<div class="gw-lq-error"><i class="fas fa-exclamation-circle me-1"></i>${escapeHtml(msg)}</div>`;
       }
 
+      // 단순 메일 목록 렌더링 (라벨 적용 UI 없음)
+      function lqShowMailList(messages) {
+        const el = lqResult();
+        el.className = 'gw-lq-result show';
+
+        if (messages.length === 0) {
+          el.innerHTML = `<div class="gw-lq-error">조건에 맞는 메일을 찾지 못했습니다. 검색어를 바꿔보세요.</div>`;
+          return;
+        }
+
+        const cards = messages.map(m => {
+          const date = new Date(m.date).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+          return `
+            <div class="gw-lq-mail-card" style="cursor:default;">
+              <div class="gw-lq-mail-info">
+                <div class="gw-lq-mail-subject">${escapeHtml(m.subject)}</div>
+                <div class="gw-lq-mail-meta">${escapeHtml(m.from)} · ${date}</div>
+                <div class="gw-lq-mail-snippet">${escapeHtml(m.snippet)}</div>
+              </div>
+            </div>`;
+        }).join('');
+
+        el.innerHTML = `
+          <div class="gw-lq-hint"><strong>${messages.length}개</strong> 메일을 찾았어요.</div>
+          <div class="gw-lq-mail-list">${cards}</div>
+        `;
+      }
+
       // 메일 카드 체크박스 리스트 렌더링
       function lqShowMailCards(messages, labelName) {
         const el = lqResult();
@@ -1418,14 +1446,11 @@
         el.innerHTML = `<div class="gw-lq-answer">${escapeHtml(answerText).replace(/\n/g, '<br>')}</div>`;
       }
 
-      // ──────────────────────────────────────────────────────────────
-      // 메인 파이프라인
-      //
-      //  [/label-route] 라벨 서치 프롬포트로 의도 분류
-      //      │
-      //      ├─ "action" → [/label-query] FC → GraphRAG + GmailApp 병렬 검색 → 메일 카드
-      //      └─ "query"  → [/run-query-async] GraphRAG local search → 텍스트 답변
-      // ──────────────────────────────────────────────────────────────
+
+      // 라벨 특화 질의 메인 파이프라인
+      // /label-query 1회 호출로 intent 분류 + FC 파라미터 추출 통합
+      // intent="action" → Gmail 우선 검색, 결과 부족 시 GraphRAG 보조
+      // intent="query"  → GraphRAG local search → 텍스트 답변
       async function runLabelQuery() {
         const userInput = document.getElementById('lq-input').value.trim();
         if (!userInput) return;
@@ -1435,59 +1460,81 @@
         lqShowLoading('요청을 분석하고 있습니다...');
 
         try {
-          // 1단계: 라벨 서치 프롬포트로 의도 분류 (action vs query)
-          const routeRes = await fetch(`${FLASK_URL}/label-route`, {
+          const fc = await fetch(`${FLASK_URL}/label-query`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               userInput,
-              labels: labels.map(l => l.name || l)   // 현재 라벨 목록을 컨텍스트로 전달
+              labels: labels.map(l => l.name || l)
             })
-          });
-          const route = await routeRes.json();
-          if (!route.ok) throw new Error(route.error || '의도 분류 실패');
+          }).then(r => r.json());
+
+          if (!fc.ok) throw new Error(fc.error || 'Function Calling 실패');
 
           // ── ACTION 경로: 라벨 적용 작업 ──
-          if (route.intent === 'action') {
-            // 2a: Function Calling으로 검색 쿼리 + 라벨명 추출
-            lqShowLoading('라벨 작업 파라미터를 추출하고 있습니다...');
-            const fcRes = await fetch(`${FLASK_URL}/label-query`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ userInput })
-            });
-            const fc = await fcRes.json();
-            if (!fc.ok) throw new Error(fc.error || 'Function Calling 실패');
+          if (fc.intent === 'action') {
 
-            // 공통: GraphRAG + Gmail 병렬 검색 → 중복 제거 병합
+            // Gmail 우선 검색 → 결과 부족 시 GraphRAG 보조
             async function lqSearchMerged(query) {
-              const [graphRagRaw, gmailResult] = await Promise.allSettled([
-                lqRunGraphRag(query).then(text => lqFetchGraphRagMessages(text)),
-                callLabelsProxy('searchEmailsForLabel', { query, maxResults: 20 })
-              ]);
-              const graphRagMsgs = graphRagRaw.status === 'fulfilled' ? graphRagRaw.value : [];
-              const gmailMsgs = (gmailResult.status === 'fulfilled' && gmailResult.value.ok)
-                ? (gmailResult.value.messages || []).map(m => ({ ...m, source: 'gmail' })) : [];
+
+              // 1단계: Gmail 먼저
+              const gmailResult = await callLabelsProxy('searchEmailsForLabel', { query, maxResults: 20 });
+              const gmailMsgs = (gmailResult.ok ? (gmailResult.messages || []) : [])
+                .map(m => ({ ...m, source: 'gmail' }));
+
+              // Gmail 결과 3건 이상이면 GraphRAG 건너뜀
+              if (gmailMsgs.length >= 3) {
+                lqShowLoading(`Gmail에서 ${gmailMsgs.length}건 검색됨`);
+                return gmailMsgs;
+              }
+
+              // 2단계: Gmail 결과 부족 → GraphRAG 보조
+              lqShowLoading(`Gmail ${gmailMsgs.length}건 → GraphRAG 보조 검색 중...`);
+              let graphRagMsgs = [];
+              try {
+                const text = await lqRunGraphRag(query);
+                graphRagMsgs = await lqFetchGraphRagMessages(text);
+              } catch (e) {
+                console.warn('[lqSearchMerged] GraphRAG 실패, Gmail 결과만 사용:', e.message);
+              }
+
+              // 중복 제거 병합 (Gmail 우선)
               const seen = new Set();
               const merged = [];
-              for (const m of [...graphRagMsgs, ...gmailMsgs]) {
+              for (const m of [...gmailMsgs, ...graphRagMsgs]) {
                 if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
               }
+
               if (merged.length === 0) {
-                throw new Error(
-                  (graphRagRaw.status === 'rejected' ? graphRagRaw.reason?.message : null)
-                  || (gmailResult.status === 'rejected' ? gmailResult.reason?.message : null)
-                  || gmailResult.value?.error
-                  || '조건에 맞는 메일을 찾지 못했습니다.'
-                );
+                throw new Error(gmailResult.error || '조건에 맞는 메일을 찾지 못했습니다.');
               }
+
               return merged;
             }
 
             if (fc.action === 'search_emails') {
               const { query, label_to_apply } = fc.params;
-              lqShowLoading(`"${query}" 검색 중... (GraphRAG + Gmail 병렬)`);
-              lqShowMailCards(await lqSearchMerged(query), label_to_apply);
+
+              // 라벨명이 있는데 현재 목록에 없으면 자동 생성
+              if (label_to_apply) {
+                const labelExists = labels.some(l => (l.name || l) === label_to_apply);
+                if (!labelExists) {
+                  lqShowLoading(`"${label_to_apply}" 라벨이 없어 자동 생성 중...`);
+                  const createRes = await callLabelsProxy('createLabel', { labelName: label_to_apply });
+                  if (!createRes.ok) throw new Error(createRes.error || '라벨 생성 실패');
+                  clearCache();
+                  activeLabel = null;
+                  await loadLabels(true);
+                }
+              }
+
+              lqShowLoading(`"${query}" 검색 중...`);
+              const results = await lqSearchMerged(query);
+              if (label_to_apply) {
+                lqShowMailCards(results, label_to_apply);
+              } else {
+                lqShowMailList(results);
+              }
 
             } else if (fc.action === 'trash_emails') {
               const { query } = fc.params;
@@ -1508,43 +1555,54 @@
               if (!applyRes.ok) throw new Error(applyRes.error);
               lqResult().className = 'gw-lq-result show';
               lqResult().innerHTML = `<div class="gw-lq-success"><i class="fas fa-check-circle me-1"></i>${applyRes.appliedCount}개 메일에 <strong>${escapeHtml(applyRes.labelName)}</strong> 라벨을 적용했어요!</div>`;
+
             } else if (fc.action === 'create_label') {
-                const labelname = fc.params?.label_name;
-                if (!labelname) { lqShowError('라벨 이름을 찾을 수 없습니다.'); return; }
+              const labelname = fc.params?.label_name;
+              if (!labelname) { lqShowError('라벨 이름을 찾을 수 없습니다.'); return; }
 
-                clearCache();
-                activeLabel = null;
-                await loadLabels(true);   // 탭 목록 새로고침
-                selectLabel(labelname);   // 새 탭 활성화
+              lqShowLoading(`"${labelname}" 라벨 생성 중...`);
 
-                lqResult.className = 'gw-lq-result show';
-                lqResult.innerHTML = `<div class="gw-lq-success">
-                    <i class="fas fa-check-circle me-1"></i>
-                    "<strong>${escapeHtml(labelname)}</strong>" 라벨이 생성되었습니다!
-                </div>`;
+              const createRes = await callLabelsProxy('createLabel', { labelName: labelname });
+              if (!createRes.ok) throw new Error(createRes.error || '라벨 생성 실패');
+
+              clearCache();
+              activeLabel = null;
+              await loadLabels(true);
+              selectLabel(labelname);
+
+              lqResult().className = 'gw-lq-result show';
+              lqResult().innerHTML = `<div class="gw-lq-success">
+                <i class="fas fa-check-circle me-1"></i>
+                "<strong>${escapeHtml(labelname)}</strong>" 라벨이 생성되었습니다!
+              </div>`;
+
+              new BroadcastChannel('olive_label_update').postMessage({
+                type: 'label_created', labelName: labelname
+              });
+
             } else if (fc.action === 'multi') {
-                for (const step of fc.actions) {
-                    if (step.action === 'create_label') {
-                        const labelname = step.params?.label_name;
-                        lqShowLoading(`"${labelname}" 라벨 생성 중…`);
-                        const res = await callLabelsProxy('createLabel', { labelName: labelname });
-                        if (!res.ok) throw new Error(res.error);
-                        clearCache(); activeLabel = null;
-                        await loadLabels(true);
-                        selectLabel(labelname);
-                    } else if (step.action === 'search_emails') {
-                        const { query, label_to_apply } = step.params;
-                        lqShowLoading(`"${query}" 검색 중…`);
-                        lqShowMailCards(await lqSearchMerged(query), label_to_apply);
-                    }
-                }
-            }
+              for (const step of fc.actions) {
+                if (step.action === 'create_label') {
+                  const labelname = step.params?.label_name;
+                  lqShowLoading(`"${labelname}" 라벨 생성 중…`);
+                  const res = await callLabelsProxy('createLabel', { labelName: labelname });
+                  if (!res.ok) throw new Error(res.error);
+                  clearCache();
+                  activeLabel = null;
+                  await loadLabels(true);
+                  selectLabel(labelname);
 
+                } else if (step.action === 'search_emails') {
+                  const { query, label_to_apply } = step.params;
+                  lqShowLoading(`"${query}" 검색 중…`);
+                  lqShowMailCards(await lqSearchMerged(query), label_to_apply);
+                }
+              }
+            }
 
           // ── QUERY 경로: 정보 질문 → GraphRAG 텍스트 답변 ──
           } else {
             lqShowLoading('GraphRAG로 메일 지식 베이스를 검색하고 있습니다...');
-            // 라벨 목록을 컨텍스트로 주입 (GraphRAG는 Gmail 라벨 메타데이터를 모름)
             const labelNames = labels.map(l => l.name || l).filter(Boolean);
             const labelCtx = labelNames.length
               ? `[${name} 계정의 Gmail 라벨 목록: ${labelNames.join(', ')}]`


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>라벨 SLM 질의 서비스 성능 개선 (P1 ~ P3)</h1>
<h2>개요</h2>
<p>라벨 특화 질의 서비스의 응답 속도 개선 및 버그 수정</p>
<hr>
<h2>변경 사항</h2>
<h3>P1 — LLM 호출 2회 → 1회 통합 (<code>app.py</code>, <code>index2.html</code>)</h3>
<p><strong>문제</strong>
기존에는 <code>/label-route</code> → <code>/label-query</code> 순서로 LLM을 2번 순차 호출했음</p>
<ul>
<li><code>/label-route</code>: action vs query 의도 분류 (LLM #1)</li>
<li><code>/label-query</code>: Function Calling으로 파라미터 추출 (LLM #2)</li>
</ul>
<p><strong>변경</strong></p>
<ul>
<li><code>/label-route</code> deprecated 처리</li>
<li><code>/label-query</code> 단일 호출로 의도 분류 + FC 파라미터 추출 통합</li>
<li><code>tool_calls</code> 유무로 intent 자동 분기
<ul>
<li>FC 발생 → <code>intent: "action"</code></li>
<li>FC 없음 → <code>intent: "query"</code></li>
</ul>
</li>
<li><code>labels</code> 컨텍스트를 <code>/label-query</code> 요청에 함께 전달 (기존 <code>/label-route</code> 역할 흡수)</li>
</ul>
<p><strong>효과</strong></p>
<ul>
<li>LLM 호출 1회 감소 → 응답 시간 1~2초 단축</li>
<li>API 비용 약 50% 절감</li>
</ul>
<hr>
<h3>P2 — GraphRAG fallback 강등 (<code>index2.html</code>)</h3>
<p><strong>문제</strong>
<code>search_emails</code> 액션에서 Gmail + GraphRAG를 무조건 병렬 실행
Gmail 결과가 충분해도 GraphRAG(10~30초)를 항상 기다려야 했음</p>
<p><strong>변경</strong></p>
<ul>
<li>Gmail 검색 먼저 실행</li>
<li>결과 3건 이상 → GraphRAG 건너뛰고 즉시 반환</li>
<li>결과 3건 미만 → GraphRAG 보조 검색 실행 후 중복 제거 병합</li>
<li>GraphRAG 실패 시 Gmail 결과만 반환 (graceful degradation)</li>
</ul>
<p><strong>효과</strong></p>
<ul>
<li>Gmail 결과 충분할 때 응답 시간 10~30초 단축</li>
</ul>
<hr>
<h3>P3 — 버그 수정 (<code>index2.html</code>)</h3>
<p><strong><code>create_label</code> 액션 버그 2개 수정</strong></p>
<ul>
<li><code>lqResult</code> DOM 요소 오참조 수정 (<code>lqResult.className</code> → <code>lqResult().className</code>)</li>
<li><code>callLabelsProxy('createLabel', ...)</code> 호출 누락 추가 (라벨이 실제로 생성되지 않던 문제)</li>
</ul>
<p><strong><code>multi</code> 액션 버그 수정</strong></p>
<ul>
<li><code>create_label</code> 스텝에서 <code>callLabelsProxy('createLabel', ...)</code> 호출 누락 추가</li>
</ul>
<hr>
<h3>추가 개선</h3>
<p><strong>search_emails UI 분기</strong></p>
<ul>
<li><code>label_to_apply</code> 있음 → 체크박스 카드 + 라벨 적용 버튼</li>
<li><code>label_to_apply</code> 없음 → 단순 메일 목록 (라벨 적용 UI 없음)</li>
</ul>
<p><strong>라벨 없으면 자동 생성</strong></p>
<ul>
<li><code>search_emails</code>에서 <code>label_to_apply</code>가 있는데 현재 라벨 목록에 없으면 자동 생성 후 메일 카드 표시</li>
<li>"학회 메일 새라벨에 넣어줘" 처럼 존재하지 않는 라벨도 바로 처리 가능</li>
</ul>
<p><strong>GraphRAG 폴링 개선</strong></p>
<ul>
<li>초반 3회 1초 간격, 이후 2초 간격으로 변경 (기존 고정 2초)</li>
<li>maxTries 60회 → 30회로 축소 (최대 대기 120초 → 63초)</li>
</ul>
<p><strong><code>/labels-proxy</code> 리다이렉트 처리 개선</strong></p>
<ul>
<li>변경 액션(<code>trashEmails</code>, <code>applyLabelToSelected</code> 등)은 302 이후 POST로 재요청</li>
<li>조회 액션(<code>getLabels</code>, <code>getLabelMessages</code> 등)은 기존처럼 GET 유지</li>
<li><code>trashEmails</code> 휴지통 이동 실패 버그 수정</li>
</ul>
<hr>
<h2>변경 파일</h2>

파일 | 변경 내용
-- | --
src/app.py | /label-route deprecated, /label-query 통합, /labels-proxy 리다이렉트 개선
src/web/production/index2.html | runLabelQuery 파이프라인 개선, UI 분기, 버그 수정

</body></html><!--EndFragment-->
</body>
</html>